### PR TITLE
 download new files first then changes and then remove and and -delay-changes flag

### DIFF
--- a/pkg/index/index_test.go
+++ b/pkg/index/index_test.go
@@ -1,0 +1,31 @@
+package index
+
+import "testing"
+
+func TestComputeDifference(t *testing.T) {
+	local := Index{Files: map[string][]byte{
+		"a": []byte("deadbeef"),
+		"b": []byte("deadbeef"),
+		"c": []byte("deadbeef"),
+		"e": []byte("deadbeef"),
+	}}
+	remote := Index{Files: map[string][]byte{
+		"a": []byte("caffeeee"),
+		"c": []byte("deadbeef"),
+		"d": []byte("deadbeef"),
+		"e": []byte("deadbeef"),
+	}}
+	added, removed, changed := local.computeDifference(&remote)
+	if len(added) != 1 || len(removed) != 1 || len(changed) != 1 {
+		t.Fatal()
+	}
+	if added[0] != "d" {
+		t.Fatal()
+	}
+	if removed[0] != "b" {
+		t.Fatal()
+	}
+	if changed[0] != "a" {
+		t.Fatal()
+	}
+}


### PR DESCRIPTION
1. change the order to first download added files, then download changed files and then remove removed files.
2. add `-delay-changes` flag that allows to atomically update the changed files after all changes have been downloaded.